### PR TITLE
fix: use variables for upstream to avoid nginx caching the ips

### DIFF
--- a/frontend/default.conf.template
+++ b/frontend/default.conf.template
@@ -1,19 +1,3 @@
-upstream auth {
-    server auth:8000;
-}
-
-upstream chat {
-    server chat:8000;
-}
-
-upstream pong {
-    server pong:8000;
-}
-
-upstream kibana {
-    server kibana:5601;
-}
-
 ssl_certificate /etc/ssl/${HOSTNAME}.crt;
 ssl_certificate_key /etc/ssl/${HOSTNAME}.key;
 ssl_protocols TLSv1.2 TLSv1.3;
@@ -35,7 +19,8 @@ server {
     server_name ~^(?<subdomain>.+)\.api\.${HOSTNAME};
 
     location / {
-        proxy_pass https://$subdomain;
+        set $upstream "$subdomain:8000";
+        proxy_pass https://$upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $remote_addr;
@@ -62,7 +47,8 @@ server {
     server_name logs.${HOSTNAME};
 
     location / {
-        proxy_pass http://kibana;
+        set $upstream "kibana:5601";
+        proxy_pass http://$upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $remote_addr;


### PR DESCRIPTION
this should fix nginx returning bad gateway when a container restarts